### PR TITLE
Use (require '["fs" :as fs]) style requires.

### DIFF
--- a/src/macchiato/fs.cljs
+++ b/src/macchiato/fs.cljs
@@ -1,8 +1,6 @@
 (ns macchiato.fs
   (:refer-clojure :exclude [exists?])
-  (:require [cljs.nodejs :as node]))
-
-(def fs (node/require "fs"))
+  (:require ["fs" :as fs]))
 
 (defn- obj->clj [obj]
   (reduce
@@ -12,66 +10,66 @@
     (js/Object.keys obj)))
 
 (defn exists? [path]
-  (.existsSync fs path))
+  (fs/existsSync path))
 
 (defn file? [path]
-  (.isFile (.lstatSync fs path)))
+  (.isFile (fs/lstatSync path)))
 
 (defn directory? [path]
-  (.isDirectory (.lstatSync fs path)))
+  (.isDirectory (fs/lstatSync path)))
 
 (defn read-dir-sync
   "Reads a folder synchronously and returns the file names as a Clojure vector."
   [path]
-  (js->clj (.readdirSync fs path)))
+  (js->clj (fs/readdirSync path)))
 
 (defn slurp [filename & {:keys [encoding]}]
   (when (exists? filename)
     (.toString
       (if encoding
-        (.readFileSync fs filename encoding)
-        (.readFileSync fs filename)))))
+        (fs/readFileSync filename encoding)
+        (fs/readFileSync filename)))))
 
 (defn slurp-async [filename cb & {:keys [encoding]}]
   (when (exists? filename)
     (let [str-cb (fn [err data] (cb err (.toString data)))]
       (if encoding
-        (.readFile fs filename encoding str-cb)
-        (.readFile fs filename str-cb)))))
+        (fs/readFile filename encoding str-cb)
+        (fs/readFile filename str-cb)))))
 
 (defn spit [filename data & {:keys [encoding mode flag]
                              :or   {encoding "utf8"
                                     mode     "0o666"
                                     flag     "w"}}]
   (let [data (if (string? data) data (str data))]
-    (.writeFileSync fs filename data encoding mode flag)))
+    (fs/writeFileSync filename data encoding mode flag)))
 
 (defn spit-async [filename data on-error & {:keys [encoding mode flag]
                                             :or   {encoding "utf8"
                                                    mode     "0o666"
                                                    flag     "w"}
                                             :as   opts}]
-  (.writeFile fs filename data (clj->js opts) on-error))
+  (fs/writeFile filename data (clj->js opts) on-error))
 
 (defn delete [file]
-  (.unlinkSync fs file))
+  (fs/unlinkSync file))
 
 (defn delete-async [file on-error]
-  (.unlink fs file on-error))
+  (fs/unlink file on-error))
 
 (defn stat [path]
   (when (exists? path)
-    (obj->clj (.statSync fs path))))
+    (obj->clj (fs/statSync path))))
 
 (defn stat-async [path cb]
   (when (exists? path)
-    (.stat fs path (fn [err stats] (cb err (obj->clj stats))))))
+    (fs/stat path (fn [err stats] (cb err (obj->clj stats))))))
 
 (defn read-stream [path]
-  (.createReadStream fs path))
+  (fs/createReadStream path))
 
 (defn write-stream [path]
-  (.createReadStream fs path))
+  (fs/createReadStream path))
 
 (defn pipe [input-stream output-stream]
-  (.pipe fs input-stream output-stream))
+  (fs/pipe input-stream output-stream))

--- a/src/macchiato/fs/path.cljs
+++ b/src/macchiato/fs/path.cljs
@@ -2,9 +2,8 @@
   (:refer-clojure :exclude [resolve])
   (:require [clojure.string :refer [ends-with?]]
             [macchiato.fs.util :refer [js-apply obj->map]]
-            [cljs.nodejs :as node]))
+            ["path" :as js-path]))
 
-(def js-path (node/require "path"))
 (def delimiter (.-delimiter js-path))
 (def separator (.-sep js-path))
 
@@ -13,21 +12,21 @@
    args: path
    return: string"
   [path]
-  (.basename js-path path))
+  (js-path/basename path))
 
 (defn dirname
   "Returns the dirname of the path
    args: [path]
    return: string"
   [path]
-  (.dirname js-path path))
+  (js-path/dirname path))
 
 (defn extension
   "Returns the extension of the file path (dot included)
    args: [path]
    return: string"
   [path]
-  (.extname js-path path))
+  (js-path/extname path))
 
 (defn format
   "Turns a map of the form returned by `parse` into a string
@@ -35,28 +34,28 @@
    returns: string"
 
   [{:keys [dir root base name ext]}]
-  (.format js-path #js {:dir dir :root root :base base :name name :ext ext}))
+  (js-path/format #js {:dir dir :root root :base base :name name :ext ext}))
 
 (defn absolute?
   "true if path is absolute
    args: [path]
    returns: bool"
   [path]
-  (.isAbsolute js-path path))
+  (js-path/isAbsolute path))
 
 (defn join
   "Joins path segments together
    args: [& segments]
    returns: string"
   [& ps]
-  (js-apply (.-join js-path) nil ps))
+  (js-apply js-path/join nil ps))
 
 (defn normalize
   "Resolves . and .. segments of path
    args: [path]
    returns: string"
   [path]
-  (.normalize js-path path))
+  (js-path/normalize path))
 
 (defn parse
   "Returns a map describing the file path
@@ -64,21 +63,21 @@
    returns: map with keys (all string values):
      :root :dir :base :ext :name"
   [path]
-  (obj->map (.parse js-path path)))
+  (obj->map (js-path/parse path)))
 
 (defn relative
   "The relative path from `from` to `to`
    args: [from to]
    returns: string"
   [from to]
-  (.relative js-path from to))
+  (js-path/relative from to))
 
 (defn resolve
   "Joins the given path segments and absolutifies
    args [& segments]
    returns: string"
   [& ps]
-  (js-apply (.-resolve js-path) nil ps))
+  (js-apply js-path/resolve nil ps))
 
 (defn with-separator
   "Receives a path, and returns the same value if it ends in a path separator,

--- a/src/macchiato/fs/path/posix.cljs
+++ b/src/macchiato/fs/path/posix.cljs
@@ -1,8 +1,8 @@
 (ns macchiato.fs.path.posix
-  (:require [cljs.nodejs :as node]
-            [macchiato.fs.util :refer [js-apply obj->map]]))
+  (:require [macchiato.fs.util :refer [js-apply obj->map]]
+            ["path" :as path]))
 
-(def posix (.-posix (node/require "path")))
+(def posix (.-posix path))
 
 (defn basename
   "Returns the basename (file without directory) of the path
@@ -74,5 +74,3 @@
    returns: string"
   [& ps]
   (js-apply (.-resolve posix) nil ps))
-
-

--- a/src/macchiato/fs/path/windows.cljs
+++ b/src/macchiato/fs/path/windows.cljs
@@ -1,8 +1,8 @@
 (ns macchiato.fs.path.windows
-  (:require [cljs.nodejs :as node]
-            [macchiato.fs.util :refer [js-apply obj->map]]))
+  (:require [macchiato.fs.util :refer [js-apply obj->map]]
+            ["path" :as path]))
 
-(def win32 (.-win32 (node/require "path")))
+(def win32 (.-win32 path))
 
 (defn basename
   "Returns the basename (file without directory) of the path

--- a/src/macchiato/fs/util.cljs
+++ b/src/macchiato/fs/util.cljs
@@ -1,5 +1,4 @@
-(ns macchiato.fs.util
-  (:require [cljs.nodejs :as node]))
+(ns macchiato.fs.util)
 
 (defn js-apply
   "Applies a javascript function to a 'this' context and arguments


### PR DESCRIPTION
Using the cljs.nodejs/require style causes issues with advanced compilation
mode.