### PR TITLE
Slurp now throws for non existing files instead of returning `nil`

### DIFF
--- a/src/macchiato/fs.cljs
+++ b/src/macchiato/fs.cljs
@@ -24,18 +24,16 @@
   (js->clj (fs/readdirSync path)))
 
 (defn slurp [filename & {:keys [encoding]}]
-  (when (exists? filename)
-    (.toString
-      (if encoding
-        (fs/readFileSync filename encoding)
-        (fs/readFileSync filename)))))
+  (.toString
+   (if encoding
+     (fs/readFileSync filename encoding)
+     (fs/readFileSync filename))))
 
 (defn slurp-async [filename cb & {:keys [encoding]}]
-  (when (exists? filename)
-    (let [str-cb (fn [err data] (cb err (.toString data)))]
-      (if encoding
-        (fs/readFile filename encoding str-cb)
-        (fs/readFile filename str-cb)))))
+  (let [str-cb (fn [err data] (cb err (.toString data)))]
+    (if encoding
+      (fs/readFile filename encoding str-cb)
+      (fs/readFile filename str-cb))))
 
 (defn spit [filename data & {:keys [encoding mode flag]
                              :or   {encoding "utf8"

--- a/test/macchiato/test/fs/core_test.cljs
+++ b/test/macchiato/test/fs/core_test.cljs
@@ -2,10 +2,11 @@
   (:require
     [clojure.set :refer [difference]]
     [macchiato.fs :as fs]
-    [cljs.test :refer-macros [is are deftest testing use-fixtures]]))
+    [cljs.test :refer-macros [is are deftest testing use-fixtures async]]))
 
 (def text-path "test/data/foo.txt")
 (def data-path "test/data/foo.edn")
+(def non-existing-path "/test/data/does-not-exists")
 
 (def text-value "this is a test")
 (def data-value {:foo "bar"})
@@ -31,6 +32,12 @@
   (fs/spit text-path text-value)
   (fs/delete text-path)
   (fs/spit-async text-path text-value (fn [_] (is false))))
+
+(deftest slurp-test
+  (fs/delete text-path)
+  (fs/spit text-path text-value)
+  (is (= text-value (fs/slurp text-path)))
+  (is (thrown? js/Error (fs/slurp non-existing-path))))
 
 (deftest slurp-async-test
   (fs/delete text-path)


### PR DESCRIPTION
Fixes: https://github.com/macchiato-framework/macchiato-core/issues/38

I didn't update async test as it doesn't work anyway - it's async and should use `async`: https://cljs.github.io/api/cljs.test/#async. I've tried but then I've got this nothing telling error:
```
FAIL in (slurp-async-test) (at FSReqWrap.oncomplete (fs.js:141:20)
expected: false
  actual: false
```

also in the async test - first argument of callback is value, but it should be error :). Maybe doo is hiding some exception that occured...

You probably noticed, but ci is complaining on `master` about present `package.json`.